### PR TITLE
fix(repo URL): update old made-js URLs to new made.js URLs

### DIFF
--- a/README.md
+++ b/README.md
@@ -46,7 +46,7 @@ npm install @exabyte-io/made.js
 From source to contribute to development:
 
 ```bash
-git clone git@github.com:Exabyte-io/made-js.git
+git clone git@github.com:Exabyte-io/made.js.git
 ```
 
 ## Contribution
@@ -124,8 +124,8 @@ in the `lint-staged` directive of the `package.json` file (by using a `husky` pr
 if you add extra whitespace to a file, stage it, and try to commit it, you will see the following:
 
 ```bash
-➜  made-js git:(feature/SOF-4398-TB) ✗ git add src/basis/constrained_basis.js
-➜  made-js git:(feature/SOF-4398-TB) ✗ git commit -m "Test commit non-linted code"
+➜  made.js git:(feature/SOF-4398-TB) ✗ git add src/basis/constrained_basis.js
+➜  made.js git:(feature/SOF-4398-TB) ✗ git commit -m "Test commit non-linted code"
 ✔ Preparing...
 ✔ Running tasks...
 ✖ Prevented an empty git commit!

--- a/package.json
+++ b/package.json
@@ -14,15 +14,15 @@
     },
     "repository": {
         "type": "git",
-        "url": "https://github.com/Exabyte-io/made-js.git"
+        "url": "https://github.com/Exabyte-io/made.js.git"
     },
     "main": "lib/made.js",
     "author": "Exabyte Inc.",
     "bugs": {
-        "url": "https://github.com/Exabyte-io/made-js/issues"
+        "url": "https://github.com/Exabyte-io/made.js/issues"
     },
     "license": "Apache-2.0",
-    "homepage": "https://github.com/Exabyte-io/made-js",
+    "homepage": "https://github.com/Exabyte-io/made.js",
     "engines": {
         "node": ">=0.12"
     },


### PR DESCRIPTION
related to https://github.com/Exabyte-io/exabyte-stack/commit/ad437b1fca4227c11396260615166213fc6e16fd and https://github.com/Exabyte-io/exabyte-stack/pull/322

https://exabyte.atlassian.net/wiki/spaces/~630535b0ed0c9b03372c6bfc/pages/2545090561/Rename+of+made-js+to+made.js+Git+submodule